### PR TITLE
Update main.go to work with install instructions

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"strconv"
 
-	v "g.maqiv.com/vimwiki_godown/vimwiki"
+	v "github.com/maqiv/vimwiki-godown/vimwiki"
 
 	"github.com/russross/blackfriday"
 )


### PR DESCRIPTION
I am not sure about the reasons why this was previously here, but with the latest toolchain on ArchLinux it is impossible to install this unless I clone the repo and install it manually:
```
git clone https://github.com/maqiv/vimwiki-godown ${GOPATH}/src/github.com/maqiv/vimwiki-godown
# apply this patch
go install
```